### PR TITLE
pass by value instead of pass by ref

### DIFF
--- a/external/rpc.go
+++ b/external/rpc.go
@@ -69,7 +69,7 @@ func (c *clefUIAPI) OnUserInputrequest(message core.UserInputRequest) (*core.Use
 
 func (c *clefUIAPI) ApproveNewAccount(p core.NewAccountRequest) (response *core.NewAccountResponse, err error) {
 	ch := make(chan *core.NewAccountResponse)
-	item := &ui.IncomingRequestItem{
+	item := ui.IncomingRequestItem{
 		From:        " - ",
 		Description: "Request for new account creation",
 		RPC: &ui.ApproveNewAccountRequest{
@@ -90,7 +90,7 @@ func (c *clefUIAPI) ApproveTx(p core.SignTxRequest) (*core.SignTxResponse, error
 		p.Transaction.To.Address().Bytes()[:4])
 
 	ch := make(chan *core.SignTxResponse)
-	item := &ui.IncomingRequestItem{
+	item := ui.IncomingRequestItem{
 		From:        p.Transaction.From.Original(),
 		Description: desc,
 		RPC: &ui.ApproveTxRequest{
@@ -120,7 +120,7 @@ func (c *clefUIAPI) ApproveListing(p core.ListRequest) (*core.ListResponse, erro
 	} else if len(p.Meta.UserAgent) > 0 {
 		desc = fmt.Sprintf("Request to list accounts (ua: %s)", p.Meta.UserAgent)
 	}
-	item := &ui.IncomingRequestItem{
+	item := ui.IncomingRequestItem{
 		From:        " - ",
 		Description: desc,
 		RPC: &ui.ApproveListingRequest{

--- a/internal/ui/start.go
+++ b/internal/ui/start.go
@@ -43,7 +43,7 @@ type ClefUI struct {
 	Mainw           *widgets.QWidget
 	currentView     string
 	BackToMain      chan bool
-	IncomingRequest chan *IncomingRequestItem
+	IncomingRequest chan IncomingRequestItem
 	operationCh     chan requestInvocation // When user clicks an op in the list, it gets sent over this chan
 	ErrorDialog     chan string
 
@@ -85,7 +85,7 @@ func (c *ClefUI) initApp() {
 
 	c.App = app
 	c.Mainw = widget
-	c.IncomingRequest = make(chan *IncomingRequestItem)
+	c.IncomingRequest = make(chan IncomingRequestItem)
 	c.operationCh = make(chan requestInvocation)
 	c.BackToMain = make(chan bool)
 	c.ErrorDialog = make(chan string)

--- a/internal/ui/tx_list.go
+++ b/internal/ui/tx_list.go
@@ -51,16 +51,16 @@ type TxListModel struct {
 
 	_ func()                        `constructor:"init"`
 	_ func()                        `signal:"clear,auto"`
-	_ func(tx *IncomingRequestItem) `signal:"add,auto"`
+	_ func(tx IncomingRequestItem) `signal:"add,auto"`
 	_ func(i int)                   `signal:"remove,auto"`
 
-	modelData    []*IncomingRequestItem
+	modelData    []IncomingRequestItem
 	idCounter    int
 	removeItemCh chan int
 }
 
 func (m *TxListModel) init() {
-	m.modelData = []*IncomingRequestItem{}
+	m.modelData = []IncomingRequestItem{}
 	m.idCounter = 0
 	m.removeItemCh = make(chan int)
 
@@ -123,14 +123,14 @@ func (m *TxListModel) data(index *core.QModelIndex, role int) *core.QVariant {
 
 func (m *TxListModel) clear() {
 	m.BeginResetModel()
-	m.modelData = []*IncomingRequestItem{}
+	m.modelData = []IncomingRequestItem{}
 	m.EndResetModel()
 }
 
-func (m *TxListModel) add(tx *IncomingRequestItem) {
-	if tx == nil {
-		return
-	}
+func (m *TxListModel) add(tx IncomingRequestItem) {
+	//if tx == nil {
+	//	return
+	//}
 	address := strings.ToLower(tx.From)
 	m.BeginInsertRows(core.NewQModelIndex(), len(m.modelData), len(m.modelData))
 	tx.ID = m.idCounter


### PR DESCRIPTION
This PR fixes a crash which occurs due to some quirk between go and c with regards to pointers, that causes invalid memory references

```
unexpected fault address 0xb01dfacedebac1e
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb01dfacedebac1e pc=0x40ee7bd]
 
goroutine 1 [running, locked to thread]:
runtime.throw(0x5cb373f, 0x5)
    /usr/local/opt/go/libexec/src/runtime/panic.go:617 +0x72 fp=0xc000207908 sp=0xc0002078d8 pc=0x4034492
runtime.sigpanic()
    /usr/local/opt/go/libexec/src/runtime/signal_unix.go:397 +0x401 fp=0xc000207938 sp=0xc000207908 pc=0x40496b1
strings.ToLower(0x4562444145447830, 0x3030303030304665, 0x44ceaf5, 0xc0003101c0)
    /usr/local/opt/go/libexec/src/strings/strings.go:587 +0x4d fp=0xc0002079d0 sp=0xc000207938 pc=0x40ee7bd
github.com/ethereum/clef-ui/internal/ui.(*TxListModel).add(0xc0001100c0, 0xc00036c2d0)
    /Users/gfz/.go/src/github.com/ethereum/clef-ui/internal/ui/tx_list.go:134 +0x47 fp=0xc000207a48 sp=0xc0002079d0 pc=0x53041f7
github.com/ethereum/clef-ui/internal/ui.(*TxListModel).add-fm(0xc00036c2d0)
    /Users/gfz/.go/src/github.com/ethereum/clef-ui/internal/ui/tx_list.go:130 +0x34 fp=0xc000207a68 sp=0xc000207a48 pc=0x53d4074
github.com/ethereum/clef-ui/internal/ui.callbackTxListModelde386d_Add(0x1bf1e140, 0xc000184370)
    /Users/gfz/.go/src/github.com/ethereum/clef-ui/internal/ui/moc.go:14115 +0x96 fp=0xc000207ab0 sp=0xc000207a68 pc=0x5388b36
github.com/ethereum/clef-ui/internal/ui._cgoexpwrap_8cd7a7f36873_callbackTxListModelde386d_Add(0x1bf1e140, 0xc000184370)
    _cgo_gotypes.go:18696 +0x35 fp=0xc000207ad0 sp=0xc000207ab0 pc=0x5335d85
runtime.call32(0x0, 0x7ffeefbfd970, 0x7ffeefbfda08, 0x10)
    /usr/local/opt/go/libexec/src/runtime/asm_amd64.s:519 +0x3b fp=0xc000207b00 sp=0xc000207ad0 pc=0x405f8fb
runtime.cgocallbackg1(0x0)
    /usr/local/opt/go/libexec/src/runtime/cgocall.go:314 +0x177 fp=0xc000207b78 sp=0xc000207b00 pc=0x400a937
runtime.cgocallbackg(0x0)
```